### PR TITLE
Update vuejs.json, inserting cases with non default delimiters

### DIFF
--- a/json/vuejs.json
+++ b/json/vuejs.json
@@ -837,6 +837,20 @@
     {
         "authors": [
             {
+                "name": "Francesco Minetti",
+                "company": "Bug hunter",
+                "twitterUrl": ""
+            }
+        ],
+        "vector": "${alert``}",
+        "hash": "",
+        "type": "reflected",
+        "csp": false,
+        "version" : 2
+    },
+    {
+        "authors": [
+            {
                 "name": "Gareth Heyes",
                 "company": "PortSwigger",
                 "twitterUrl": "https:\/\/twitter.com\/garethheyes"


### PR DESCRIPTION
Hi everyone,
When there is a Vue.js code like:

`new Vue({
  delimiters: ['${', '}']
})`

and an attacker can insert a payload like: `${alert``}` even if the payload ended up in a DOM text node, the Vue.js parser will interpret this as template and execute the injected JS.

tested on version 2.6.10
