### PR TITLE
Remove Firefox-only marquee events after v126 releases

### DIFF
--- a/json/classic.json
+++ b/json/classic.json
@@ -162,17 +162,38 @@
     },
     {
         "description": "onloadstart event for media elements in Firefox v107 and below",
-         "code": "<img src=validimage.png onloadstart=alert(1)>",
-                "browsers": [
-                    "firefox"
-                ]
+        "code": "<img src=validimage.png onloadstart=alert(1)>",
+        "browsers": [
+            "firefox"
+        ]
 
     },
     {
         "description": "onloadend event for media elements in Firefox v107 and below",
         "code": "<input type=image onloadend=alert(1) src=validimage.png>",
-                "browsers": [
-                    "firefox"
-                ]
+        "browsers": [
+            "firefox"
+        ]
+    },
+    {
+        "description": "onbounce event for marquee element in Firefox v125 and below",
+        "code": "<marquee width=1 loop=1 onbounce=alert(1)>XSS<\/marquee>",
+        "browsers": [
+            "firefox"
+        ]
+    },
+    {
+        "description": "onfinish event for marquee element in Firefox v125 and below",
+        "code": "<marquee width=1 loop=1 onfinish=alert(1)>XSS<\/marquee>",
+        "browsers": [
+            "firefox"
+        ]
+    },
+    {
+        "description": "onstart event for marquee element in Firefox v125 and below",
+        "code": "<marquee onstart=alert(1)>XSS<\/marquee>",
+        "browsers": [
+            "firefox"
+        ]
     }
 ]

--- a/json/events.json
+++ b/json/events.json
@@ -3198,19 +3198,6 @@
             }
         ]
     },
-    "onbounce": {
-        "description": "Fires when the marquee bounces",
-        "tags": [
-            {
-                "tag": "marquee",
-                "code": "<marquee width=1 loop=1 onbounce=alert(1)>XSS<\/marquee>",
-                "browsers": [
-                    "firefox"
-                ],
-                "interaction": false
-            }
-        ]
-    },
     "oncanplay": {
         "description": "Fires if the resource can be played",
         "tags": [
@@ -3686,19 +3673,6 @@
                 "browsers": [
                     "chrome",
                     "safari"
-                ],
-                "interaction": false
-            }
-        ]
-    },
-    "onfinish": {
-        "description": "Fires when the marquee finishes",
-        "tags": [
-            {
-                "tag": "marquee",
-                "code": "<marquee width=1 loop=1 onfinish=alert(1)>XSS<\/marquee>",
-                "browsers": [
-                    "firefox"
                 ],
                 "interaction": false
             }
@@ -9175,19 +9149,6 @@
                     "safari"
                 ],
                 "interaction": true
-            }
-        ]
-    },
-    "onstart": {
-        "description": "Fires when the marquee starts",
-        "tags": [
-            {
-                "tag": "marquee",
-                "code": "<marquee onstart=alert(1)>XSS<\/marquee>",
-                "browsers": [
-                    "firefox"
-                ],
-                "interaction": false
             }
         ]
     },


### PR DESCRIPTION
We are removing the Firefox-only `<marquee>` events `bounce`, `start`, `finish` in Firefox 126: https://bugzilla.mozilla.org/show_bug.cgi?id=1689705. The planned release is May 14, so this should probably wait for a bit before merging.

(This is similar to #41)