### PR TITLE
Works in all browsers: SVG script href attribute without closing script tag

### DIFF
--- a/json/protocols.json
+++ b/json/protocols.json
@@ -67,7 +67,7 @@
   {
     "description": "SVG script href attribute without closing script tag",
     "code": "<svg><script href=\"data:text/javascript,alert(1)\" />",
-    "browsers": ["firefox"]
+    "browsers": ["chrome", "firefox", "safari"]
   },
   {
     "description": "SVG use element Chrome/Firefox",


### PR DESCRIPTION
I tested this by going to:

https://portswigger-labs.net/xss/xss.php?x=%3Csvg%3E%3Cscript%20href%3D%22data%3Atext%2Fjavascript%2Calert%281%29%22%20%2F%3E&context=html

